### PR TITLE
fix: keep queued_requests in sync with ml_tasks (stop unbounded queue growth)

### DIFF
--- a/modelq/app/base.py
+++ b/modelq/app/base.py
@@ -293,7 +293,8 @@ class ModelQ:
                     
                     # Push it back into ml_tasks
                     self.redis_client.rpush("ml_tasks", json.dumps(task_dict))
-    
+                    self.redis_client.zadd("queued_requests", {task_id: now})
+
                     # Remove from processing set
                     self.redis_client.srem("processing_tasks", task_id)
 
@@ -487,7 +488,8 @@ class ModelQ:
 
     def delete_queue(self):
         self.redis_client.ltrim("ml_tasks", 1, 0)
-        
+        self.redis_client.delete("queued_requests")
+
     def enqueue_delayed_task(self, task_dict: dict, delay_seconds: int):
         """
         Enqueues a task into a Redis sorted set ('delayed_tasks') to be processed later.
@@ -508,6 +510,11 @@ class ModelQ:
             for task_json in ready_tasks:
                 self.redis_client.zrem("delayed_tasks", task_json)
                 self.redis_client.lpush("ml_tasks", task_json)
+                try:
+                    _td = json.loads(task_json)
+                    self.redis_client.zadd("queued_requests", {_td["task_id"]: _td.get("queued_at", now)})
+                except Exception:
+                    pass
             time.sleep(1)
 
     def requeue_inprogress_tasks(self):
@@ -682,6 +689,12 @@ class ModelQ:
                         continue
                     task.status = "processing"
 
+                    # The task has left the queue (claimed for processing). Keep the
+                    # `queued_requests` index in sync with `ml_tasks`; otherwise it
+                    # accumulates every completed/failed task forever and badly
+                    # inflates queue_num / queue_time.
+                    self.redis_client.zrem("queued_requests", task.task_id)
+
                     # Set started_at
                     task_dict["started_at"] = time.time()
 
@@ -734,6 +747,8 @@ class ModelQ:
                             f"Worker {worker_id} cannot process task {task.task_name}, re-queueing..."
                         )
                         self.redis_client.rpush("ml_tasks", task_json)
+                        self.redis_client.zadd("queued_requests", {task.task_id: task_dict.get("queued_at", time.time())})
+                        self.redis_client.srem("processing_tasks", task.task_id)
 
                 except Exception as e:
                     logger.error(


### PR DESCRIPTION
## Problem

`queued_requests` (the Redis sorted set scored by `queued_at`, which `queue_num` / `queue_time` are computed from) is `zadd`-ed on enqueue but only `zrem`-ed in `remove_task_from_queue()` (explicit cancel). The normal lifecycle — `blpop("ml_tasks")` claim → process → complete — **never removes the task from `queued_requests`**.

So `queued_requests` grows without bound: every task ever enqueued stays in it forever. In production one deepfake queue held **934,500** entries of which **~99.5% were already-resolved** (success/error) tasks — only ~44 were genuinely pending. This made `queue_num`/`queue_time` meaningless (and drove bogus autoscaling/ETA) and bloated the memory-capped Redis containers.

`ml_tasks` (the actual work list) drains correctly via `blpop`; it's only the parallel index that leaks.

## Fix

Keep `queued_requests` mirroring `ml_tasks` at every boundary:

- **Claim** (`blpop` in the worker loop): `zrem("queued_requests", task_id)` once the task is picked up — it's no longer queued.
- **Re-queue** paths re-add it: stuck-processing requeue, delayed-task requeue, and task-not-allowed requeue now `zadd("queued_requests", ...)` (the not-allowed path also `srem`s `processing_tasks`).
- **`delete_queue()`** now also clears `queued_requests`.

## Tests

All **49** tests pass (`tests/test_base.py`, fakeredis). The existing `queued_requests` assertions are post-enqueue and unaffected.

> Note: this prevents future growth. The existing backlog of stale entries should be pruned separately (a one-time purge of ~6.8M entries across 36 queues was already run).
