### PR TITLE
feat: graceful SIGTERM/SIGINT worker drain (finish in-flight task before exit)

### DIFF
--- a/modelq/app/base.py
+++ b/modelq/app/base.py
@@ -152,6 +152,9 @@ class ModelQ:
             )
 
         self.worker_threads = []
+        # Set on SIGTERM/SIGINT so worker loops stop pulling and exit cleanly
+        # after finishing their current task (see shutdown()).
+        self._shutdown_event = threading.Event()
         if server_id is None:
             # Attempt to load the server_id from a local file:
             server_id = self._get_or_create_server_id_file()
@@ -662,6 +665,21 @@ class ModelQ:
             return wrapper
         return decorator
 
+    def shutdown(self, timeout: float = 300.0):
+        """Signal worker loops to stop after their current task, then wait.
+
+        Called on SIGTERM/SIGINT (see the CLI) so an in-flight task finishes —
+        and, for synchronous task handlers, its upload completes — before the
+        process exits, instead of daemon worker threads being killed mid-task
+        (which orphans the task and loses its result). Waits up to `timeout`
+        seconds in total for the workers to drain.
+        """
+        self._shutdown_event.set()
+        deadline = time.time() + timeout
+        for thread in self.worker_threads:
+            remaining = max(0.1, deadline - time.time())
+            thread.join(timeout=remaining)
+
     def start_workers(self, no_of_workers: int = 1):
         """
         Starts worker threads to pop tasks from 'ml_tasks' and process them.
@@ -703,7 +721,7 @@ class ModelQ:
         # 4) Worker threads
         def worker_loop(worker_id):
             self.check_middleware("after_worker_boot")
-            while True:
+            while not self._shutdown_event.is_set():
                 try:
                     # Check worker health before picking up tasks
                     if not self.worker_healthy:
@@ -712,7 +730,7 @@ class ModelQ:
                         continue
 
                     self.update_server_status(f"worker_{worker_id}: idle")
-                    task_data = self.redis_client.blpop("ml_tasks")  # blocks until a task is available
+                    task_data = self.redis_client.blpop("ml_tasks", timeout=5)  # wake every 5s so shutdown is noticed promptly
                     if not task_data:
                         continue
 

--- a/modelq/app/cli/main.py
+++ b/modelq/app/cli/main.py
@@ -93,7 +93,11 @@ def run_workers(
         raise typer.Exit(1)
     finally:
         logger.info("Shutting down workers...")
-        typer.echo("🛑 Shutting down workers...")
+        typer.echo("🛑 Draining workers (finishing any in-flight task)...")
+        try:
+            app_instance.shutdown()
+        except Exception as e:
+            logger.warning(f"Error while draining workers: {e}")
         typer.echo("✅ Shutdown complete")
 
 @app.command()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "modelq"
-version = "1.0.14"
+version = "1.0.15"
 description = "Celery-like task queue for ML inference."
 authors = ["Tanmaypatil123 <tanmay@modelslab.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Problem
`run-workers` registers a SIGTERM handler that only sets a flag, but the worker loop runs `while True` and never checks it, and the worker threads are `daemon=True`. So on SIGTERM the process exits and kills them **mid-task**, orphaning the in-flight task (and losing its result when the task handler uploads synchronously). This is a root cause of serverless replicas being scaled down mid-generation and 404-ing their output.

## Change
- Worker loop: `while not self._shutdown_event.is_set()` + `blpop("ml_tasks", timeout=5)` so shutdown is noticed within ~5s.
- New `ModelQ.shutdown(timeout=300)`: sets the event and `join()`s the worker threads so the **current task finishes** (and, for synchronous handlers, its upload completes) before exit.
- CLI calls `app_instance.shutdown()` on SIGTERM/SIGINT.

Existing behavior is unchanged during normal operation; only the shutdown path drains gracefully. Pairs with gpulab-v2 graceful `docker stop` on scale-down and the flux-klein-server synchronous-upload fix.

Version bump 1.0.14 → **1.0.15**. Publishing the GitHub release triggers the PyPI publish (cd.yml).