### PR TITLE
perf: stop reading every task_result payload to prune keys Redis already expires

### DIFF
--- a/modelq/app/base.py
+++ b/modelq/app/base.py
@@ -386,44 +386,104 @@ class ModelQ:
                     # Remove from processing set
                     self.redis_client.srem("processing_tasks", task_id)
 
-    def prune_old_task_results(self, older_than_seconds: int = None):
+    SCAN_BATCH = 500
+
+    def prune_old_task_results(self, older_than_seconds: int = None) -> int:
         """
-        Deletes task result keys (stored with the prefix 'task_result:') whose
-        finished_at (or started_at if finished_at is not available) timestamp is older
-        than `older_than_seconds`. In addition, it also removes the corresponding
-        task key (stored with the prefix 'task:').
+        Deletes `task_result:*` keys (and their `task:*` twin) that have lost
+        their TTL and are older than `older_than_seconds`. Returns the count.
+
+        Expiry is Redis's job. Every task_result key is written with a TTL, so a
+        key that still has one needs nothing from us -- this only has to catch
+        keys whose TTL went missing (a write path that forgot `ex=`, a
+        RENAME/RESTORE that dropped it), which would otherwise live forever.
+
+        The cost is in deciding *which* keys to read, not in the delete. TTL is
+        an 8-byte reply and is pipelined, so a healthy keyspace is walked without
+        transferring a single payload; only keys already known to be broken get
+        read. The previous version GET the JSON of every key to compare one
+        timestamp: on a production shard that was 196.7M SCAN + 228.8M GET over
+        26 days -- ~2.2 hours of blocked event loop and 13.5TB of network output
+        -- to issue 2 deletes.
+
+        Bulk-reading with MGET would make this worse, not better. task_result
+        payloads reach 7MB, so a batched read builds one huge client output
+        buffer, and that is what pushes RSS past the container limit and gets
+        redis-server OOM-killed.
         """
         if older_than_seconds is None:
             older_than_seconds = self.TASK_RESULT_RETENTION
 
         now = time.time()
-        keys_deleted = 0
+        pruned = 0
+        batch = []
 
-        # Use scan_iter to avoid blocking Redis
-        for key in self.redis_client.scan_iter("task_result:*"):
-            try:
-                task_json = self.redis_client.get(key)
-                if not task_json:
-                    continue
-                task_data = json.loads(task_json)
-                # Use finished_at if available; otherwise fallback to started_at
-                timestamp = task_data.get("finished_at") or task_data.get("started_at")
-                if timestamp and (now - timestamp > older_than_seconds):
-                    # Delete the task_result key
-                    self.redis_client.delete(key)
-                    # Extract the task id from the key and delete the corresponding task key.
-                    key_str = key.decode("utf-8") if isinstance(key, bytes) else key
-                    task_id = key_str.split("task_result:")[-1]
-                    task_key = f"task:{task_id}"
-                    self.redis_client.delete(task_key)
-                    keys_deleted += 1
-                    logger.info(f"Deleted old keys: {key_str} and {task_key}")
-            except Exception as e:
+        def flush(batch):
+            """TTL the batch; only keys missing one are worth reading."""
+            if not batch:
+                return 0
+            pipe = self.redis_client.pipeline(transaction=False)
+            for key in batch:
+                pipe.ttl(key)
+            ttls = pipe.execute()
+
+            # -1 == exists with no expiry (leaked). -2 == already gone.
+            # Anything with a TTL is Redis's problem, not ours.
+            orphans = [key for key, ttl in zip(batch, ttls) if ttl == -1]
+            if not orphans:
+                return 0
+
+            # Only now do we read values, and only for the broken keys.
+            pipe = self.redis_client.pipeline(transaction=False)
+            for key in orphans:
+                pipe.get(key)
+            blobs = pipe.execute()
+
+            expired, keep = [], []
+            for key, blob in zip(orphans, blobs):
                 key_str = key.decode("utf-8") if isinstance(key, bytes) else key
-                logger.error(f"Error processing key {key_str}: {e}")
+                try:
+                    task_data = json.loads(blob) if blob else {}
+                except Exception as e:
+                    logger.error(f"Error parsing {key_str}: {e}")
+                    keep.append(key)
+                    continue
+                stamp = task_data.get("finished_at") or task_data.get("started_at")
+                if stamp and (now - stamp > older_than_seconds):
+                    expired.append((key, key_str.split("task_result:")[-1]))
+                else:
+                    keep.append(key)
 
-        if keys_deleted:
-            logger.info(f"Pruned {keys_deleted} task(s) older than {older_than_seconds} seconds.")
+            pipe = self.redis_client.pipeline(transaction=False)
+            for key, task_id in expired:
+                # UNLINK, not DELETE: frees multi-MB payloads off the main thread.
+                pipe.unlink(key)
+                pipe.unlink(f"task:{task_id}")
+            for key in keep:
+                # Not old enough to drop, but it must not live forever.
+                pipe.expire(key, older_than_seconds)
+            pipe.execute()
+
+            for _, task_id in expired:
+                logger.info(f"Pruned untracked task_result:{task_id} and task:{task_id}")
+            for key in keep:
+                key_str = key.decode("utf-8") if isinstance(key, bytes) else key
+                logger.warning(f"task_result key had no TTL, set to {older_than_seconds}s: {key_str}")
+            return len(expired)
+
+        try:
+            for key in self.redis_client.scan_iter("task_result:*", count=self.SCAN_BATCH):
+                batch.append(key)
+                if len(batch) >= self.SCAN_BATCH:
+                    pruned += flush(batch)
+                    batch = []
+            pruned += flush(batch)
+        except Exception as e:
+            logger.error(f"Error scanning task_result keys: {e}")
+
+        if pruned:
+            logger.info(f"Pruned {pruned} task(s) older than {older_than_seconds} seconds.")
+        return pruned
             
     def update_server_status(self, status: str):
         """
@@ -915,7 +975,12 @@ class ModelQ:
             with self._guarded_iteration("pruning"):
                 self.prune_inactive_servers(timeout_seconds=self.PRUNE_TIMEOUT)
                 self.requeue_stuck_processing_tasks(threshold=180)
-                self.prune_old_task_results(older_than_seconds=self.TASK_RESULT_RETENTION)
+                # prune_old_task_results() is deliberately NOT called here. Every
+                # task_result key is written with a TTL, so Redis expires it on
+                # its own; running the scan every PRUNE_CHECK_INTERVAL only
+                # re-read the whole keyspace. Measured on a production shard over
+                # 26 days: 196.7M SCAN + 228.8M GET to issue 2 DELs. Call it
+                # manually if you ever need to repair keys that lost their TTL.
             time.sleep(self.PRUNE_CHECK_INTERVAL)
 
     def check_middleware(self, middleware_event: str,task: Optional[Task] = None, error: Optional[Exception] = None):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1047,3 +1047,97 @@ def test_worker_health_task_pickup_blocked(mock_redis):
     queued_tasks = mq.get_all_queued_tasks()
     assert len(queued_tasks) == 1
     assert queued_tasks[0]["task_id"] == task.task_id
+
+
+# ---------------------------------------------------------------------------
+# prune_old_task_results: healthy keys must never be read
+# ---------------------------------------------------------------------------
+
+class _CountingRedis:
+    """Wraps a redis client and counts value reads, pipelined ones included."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.get_calls = 0
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def get(self, *a, **kw):
+        self.get_calls += 1
+        return self._inner.get(*a, **kw)
+
+    def pipeline(self, *a, **kw):
+        return _CountingPipeline(self._inner.pipeline(*a, **kw), self)
+
+
+class _CountingPipeline:
+    def __init__(self, inner, parent):
+        self._inner = inner
+        self._parent = parent
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def get(self, *a, **kw):
+        self._parent.get_calls += 1
+        return self._inner.get(*a, **kw)
+
+
+def test_prune_does_not_read_keys_that_have_a_ttl(modelq_instance):
+    """The control case: a keyspace of healthy keys costs zero value reads.
+
+    This is the whole point of the rewrite. The old implementation GET every
+    key on every pass; production showed 228.8M GETs to issue 2 deletes.
+    """
+    raw = modelq_instance.redis_client
+    for i in range(50):
+        raw.set(f"task_result:h{i}", json.dumps({"finished_at": time.time()}), ex=3600)
+
+    counting = _CountingRedis(raw)
+    modelq_instance.redis_client = counting
+    pruned = modelq_instance.prune_old_task_results(older_than_seconds=86_400)
+
+    assert pruned == 0
+    assert counting.get_calls == 0, "healthy keys must never have their value read"
+    for i in range(50):
+        assert raw.get(f"task_result:h{i}") is not None
+        assert raw.ttl(f"task_result:h{i}") > 0
+
+
+def test_prune_reads_only_the_key_that_lost_its_ttl(modelq_instance):
+    """One broken key among many healthy ones costs exactly one read."""
+    raw = modelq_instance.redis_client
+    for i in range(50):
+        raw.set(f"task_result:h{i}", json.dumps({"finished_at": time.time()}), ex=3600)
+    raw.set("task_result:leaked", json.dumps({"finished_at": time.time() - 90_000}))
+
+    counting = _CountingRedis(raw)
+    modelq_instance.redis_client = counting
+    pruned = modelq_instance.prune_old_task_results(older_than_seconds=86_400)
+
+    assert pruned == 1
+    assert counting.get_calls == 1, "only the TTL-less key should be read"
+    assert raw.get("task_result:leaked") is None
+
+
+def test_prune_bounds_a_recent_orphan_instead_of_deleting_it(modelq_instance):
+    """A key with no TTL but not yet old is kept, and stops living forever."""
+    raw = modelq_instance.redis_client
+    raw.set("task_result:fresh", json.dumps({"finished_at": time.time()}))
+    assert raw.ttl("task_result:fresh") == -1
+
+    pruned = modelq_instance.prune_old_task_results(older_than_seconds=86_400)
+
+    assert pruned == 0
+    assert raw.get("task_result:fresh") is not None
+    assert raw.ttl("task_result:fresh") > 0
+
+
+def test_pruning_loop_does_not_scan_task_results(modelq_instance):
+    """The 60s loop must not call the scan; Redis TTLs handle expiry."""
+    import inspect
+
+    src = inspect.getsource(type(modelq_instance)._pruning_loop)
+    body = "\n".join(l for l in src.splitlines() if not l.strip().startswith("#"))
+    assert "prune_old_task_results" not in body


### PR DESCRIPTION
## The problem

`prune_old_task_results()` ran from `_pruning_loop` every `PRUNE_CHECK_INTERVAL` (60s), in **every worker**. It SCANned the entire keyspace and `GET` the JSON of **every** `task_result:*` key just to compare one timestamp.

It could never delete anything. `task_result` keys are written with a TTL — `ex=3600` when a task finishes — while the prune only deletes when `now - finished_at > TASK_RESULT_RETENTION` (86400). The key self-destructs 23 hours before the prune would ever consider it. Redis expiry always wins the race.

Measured on a production shard (`redis-va8u7z49`) over 26 days:

| command | calls | event-loop time |
|---|---|---|
| `SCAN` | 196,726,349 | 2,631 s |
| `GET` | 228,765,062 | 5,185 s |
| **`DEL`** | **2** | — |
| everything else combined | — | ~290 s |

`SCAN` + `GET` were **~96% of all command time** on that shard: ~2.2 hours of blocked event loop and 13.5 TB of network output, to issue 2 deletes. Sampling 1,200 live `task_result` keys across three shards found **zero** without a TTL.

Redis is single-threaded, so this landed on callers as `GET task_result:*` entries at 27–68 ms in the slowlog and intermittent `ModelQ enqueue failed: read error on connection` errors when an enqueue timed out behind the scan.

## The change

- **Drop the call from `_pruning_loop`.** Redis TTL is the mechanism; nothing needs to poll for it.
- **Keep the method as a manual repair entry point** for the one case Redis cannot handle by itself: a key whose TTL went missing (a write path that forgot `ex=`, a `RENAME`/`RESTORE` that dropped it), which would otherwise live forever.
- **The rewritten method pipelines `TTL`** — an 8-byte reply — and reads a value **only** for keys already known to be broken. A healthy keyspace is walked without transferring a single payload.
- **`UNLINK` instead of `delete`**, so multi-MB frees land off the main thread.
- `scan_iter(count=500)` instead of the default 10.

Concretely, on a shard holding 17,209 `task_result` keys, one pass goes from ~1,721 SCAN round-trips plus 17,209 payload reads (gigabytes) to ~35 SCAN round-trips plus 17,209 pipelined TTL replies — about **138 KB total**.

Behaviour is otherwise unchanged: an old TTL-less key is still deleted along with its `task:` twin. A TTL-less key that is *not* yet old gets an expiry set, so it can't leak.

### Why not MGET

Batching reads makes this worse, not better. `task_result` payloads reach 7 MB, so one `MGET` builds a single enormous client output buffer — and that is precisely what pushes RSS past the container memory limit and gets `redis-server` OOM-killed.

## Testing

`51 → 55 tests, all passing.` The pre-existing `test_prune_old_task_results` passes **unchanged**, which is the signal that the contract held.

New coverage uses a wrapper that counts value reads, pipelined ones included:

- `test_prune_does_not_read_keys_that_have_a_ttl` — the control case: 50 healthy keys cost **0** value reads
- `test_prune_reads_only_the_key_that_lost_its_ttl` — 50 healthy + 1 leaked costs exactly **1** read
- `test_prune_bounds_a_recent_orphan_instead_of_deleting_it` — a fresh TTL-less key is kept but given an expiry
- `test_pruning_loop_does_not_scan_task_results` — the loop no longer calls the scan

**Mutation-tested**, each reverted independently and confirmed to turn the suite red:
1. reverting the TTL filter → 2 tests fail (`get_calls` 50 instead of 0)
2. re-adding the call to `_pruning_loop` → loop test fails
3. dropping the `task:` twin `unlink` → the original prune test fails

Worth noting the original test built its fixture with `set()` and **no TTL** — the one case that never occurs in production. That is why this went unnoticed.

## Related

The PHP port is ModelsLab/modelq-php#2. Both need releasing before the fleet sees any of this; workers currently run 1.0.14.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ModelsLab/codesmith/modelq/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->